### PR TITLE
Changes

### DIFF
--- a/Sources/Sliders/Base/EditingRange.swift
+++ b/Sources/Sliders/Base/EditingRange.swift
@@ -1,0 +1,12 @@
+import Foundation
+
+public struct EditingRange: OptionSet {
+    public let rawValue: UInt8
+
+    public init(rawValue: UInt8) {
+        self.rawValue = rawValue
+    }
+
+    public static let upper = EditingRange(rawValue: 0b01)
+    public static let lower = EditingRange(rawValue: 0b10)
+}

--- a/Sources/Sliders/Base/PrecisionScrubbing.swift
+++ b/Sources/Sliders/Base/PrecisionScrubbing.swift
@@ -28,9 +28,9 @@ public extension View {
     ) -> some View  {
         self.environment(
             \.precisionScrubbing,
-             PrecisionScrubbingConfig { offset in
-                 scrubValue(offset).rawValue
-             } onChange: { value in
+            PrecisionScrubbingConfig { offset in
+                scrubValue(offset).rawValue
+            } onChange: { value in
                 guard let value else {
                     onChange?(nil)
                     return

--- a/Sources/Sliders/Base/PrecisionScrubbing.swift
+++ b/Sources/Sliders/Base/PrecisionScrubbing.swift
@@ -1,0 +1,23 @@
+import SwiftUI
+
+struct PrecisionScrubbingKey: EnvironmentKey {
+    static let defaultValue: (Float) -> Float = { _ in 1 }
+}
+
+extension EnvironmentValues {
+    var precisionScrubbing: (Float) -> Float {
+        get { self[PrecisionScrubbingKey.self] }
+        set { self[PrecisionScrubbingKey.self] = newValue }
+    }
+}
+
+public extension View {
+    func precisionScrubbing<ScrubValue: RawRepresentable>(
+        _ getScrubValue: @escaping (Float) -> ScrubValue
+    ) -> some View
+    where ScrubValue.RawValue == Float {
+        self.environment(\.precisionScrubbing, { offset in
+            getScrubValue(offset).rawValue
+        })
+    }
+}

--- a/Sources/Sliders/Base/PrecisionScrubbing.swift
+++ b/Sources/Sliders/Base/PrecisionScrubbing.swift
@@ -1,23 +1,47 @@
 import SwiftUI
 
+public struct PrecisionScrubbingConfig {
+    let scrubValue: (Float) -> Float
+    let onChange: ((Float?) -> Void)?
+}
+
 struct PrecisionScrubbingKey: EnvironmentKey {
-    static let defaultValue: (Float) -> Float = { _ in 1 }
+    typealias Value = PrecisionScrubbingConfig
+
+    static let defaultValue: PrecisionScrubbingConfig = PrecisionScrubbingConfig(
+        scrubValue: { _ in 1 },
+        onChange: nil
+    )
 }
 
 extension EnvironmentValues {
-    var precisionScrubbing: (Float) -> Float {
+    var precisionScrubbing: PrecisionScrubbingConfig {
         get { self[PrecisionScrubbingKey.self] }
         set { self[PrecisionScrubbingKey.self] = newValue }
     }
 }
 
 public extension View {
-    func precisionScrubbing<ScrubValue: RawRepresentable>(
-        _ getScrubValue: @escaping (Float) -> ScrubValue
-    ) -> some View
-    where ScrubValue.RawValue == Float {
-        self.environment(\.precisionScrubbing, { offset in
-            getScrubValue(offset).rawValue
-        })
+    func precisionScrubbing<ScrubValue: RawRepresentable<Float>>(
+        _ scrubValue: @escaping (Float) -> ScrubValue,
+        onChange: ((ScrubValue?) -> Void)? = nil
+    ) -> some View  {
+        self.environment(
+            \.precisionScrubbing,
+             PrecisionScrubbingConfig { offset in
+                 scrubValue(offset).rawValue
+             } onChange: { value in
+                guard let value else {
+                    onChange?(nil)
+                    return
+                }
+
+                if let value = ScrubValue(rawValue: value) {
+                    onChange?(value)
+                } else {
+                    print("Invalid conversion")
+                }
+            }
+        )
     }
 }

--- a/Sources/Sliders/Base/SliderGestureState.swift
+++ b/Sources/Sliders/Base/SliderGestureState.swift
@@ -2,61 +2,30 @@ import Foundation
 import SwiftUI
 
 public struct SliderGestureState: Equatable {
-    enum Speed: Float, Comparable, CaseIterable {
-        static func < (lhs: SliderGestureState.Speed, rhs: SliderGestureState.Speed) -> Bool {
-            lhs.rawValue < rhs.rawValue
-        }
-
-        case normal = 1
-        case half = 2
-        case quarter = 4
-        case eighth = 8
-    }
-
-    let precisionScrubbing: Bool
-    var speed = Speed.normal
-
     private var lastOffset: CGFloat
-    private var accumulations: [Speed:CGFloat] = [
-        .normal: 0
-    ]
+    private var accumulations: [Float:CGFloat] = [1: 0]
 
     var offset: CGFloat {
         accumulations.reduce(0) { accum, tuple in
             let (speed, value) = tuple
-            let appliedValue = precisionScrubbing ? value / CGFloat(speed.rawValue) : value
-            return accum + appliedValue
+            return accum + value / CGFloat(speed)
         }
     }
 
-    init(precisionScrubbing: Bool, initialOffset: CGFloat) {
-        self.precisionScrubbing = precisionScrubbing
+    init(initialOffset: CGFloat) {
         self.lastOffset = initialOffset
     }
 
-    private func speed(crossAxisOffset: CGFloat) -> Speed {
-        if abs(crossAxisOffset) > 300 {
-            return .eighth
-        } else if abs(crossAxisOffset) > 200 {
-            return .quarter
-        } else if abs(crossAxisOffset) > 100 {
-            return .half
-        } else {
-            return .normal
-        }
-    }
-
-    func updating(with offset: CGFloat, crossAxisOffset: CGFloat) -> Self {
+    func updating(with offset: CGFloat, speed: Float) -> Self {
         var mutSelf = self
 
-        let speed = speed(crossAxisOffset: crossAxisOffset)
-        mutSelf.speed = speed
+        var accumulations = self.accumulations.reduce([:]) { (accum: [Float:CGFloat], element) in
+            let (elementSpeed, elementValue) = element
 
-        var accumulations = Speed.allCases.reduce([:]) { (accum: [Speed:CGFloat], accumSpeed: Speed) in
             var out = accum
 
-            let appliedSpeed = min(accumSpeed, speed)
-            out[appliedSpeed] = (out[appliedSpeed] ?? 0) + (self.accumulations[accumSpeed] ?? 0)
+            let appliedSpeed = min(elementSpeed, speed)
+            out[appliedSpeed] = (out[appliedSpeed] ?? 0) + elementValue
 
             return out
         }

--- a/Sources/Sliders/Base/SliderGestureState.swift
+++ b/Sources/Sliders/Base/SliderGestureState.swift
@@ -1,0 +1,53 @@
+import Foundation
+import SwiftUI
+
+public struct SliderGestureState: Equatable {
+    enum Speed: CGFloat {
+        case normal = 1
+        case half = 0.5
+        case quarter = 0.25
+        case eighth = 0.125
+    }
+
+    let precisionScrubbing: Bool
+    var speed = Speed.normal
+
+    private var lastOffset: CGFloat
+    private var accumulations: [Speed:CGFloat] = [
+        .normal: 0
+    ]
+
+    var offset: CGFloat {
+        accumulations.reduce(0) { accum, tuple in
+            let (speed, value) = tuple
+            let appliedValue = precisionScrubbing ? speed.rawValue * value : value
+            return accum + appliedValue
+        }
+    }
+
+    init(precisionScrubbing: Bool, initialOffset: CGFloat) {
+        self.precisionScrubbing = precisionScrubbing
+        self.lastOffset = initialOffset
+    }
+
+    private func speed(crossAxisOffset: CGFloat) -> Speed {
+        if abs(crossAxisOffset) > 200 {
+            return .eighth
+        } else if abs(crossAxisOffset) > 150 {
+            return .quarter
+        } else if abs(crossAxisOffset) > 100 {
+            return .half
+        } else {
+            return .normal
+        }
+    }
+
+    func updating(with offset: CGFloat, crossAxisOffset: CGFloat) -> Self {
+        var mutSelf = self
+        let speed = speed(crossAxisOffset: crossAxisOffset)
+        mutSelf.speed = speed
+        mutSelf.accumulations[speed] = (accumulations[speed] ?? 0) + offset - lastOffset
+        mutSelf.lastOffset = offset
+        return mutSelf
+    }
+}

--- a/Sources/Sliders/Base/SliderGestureState.swift
+++ b/Sources/Sliders/Base/SliderGestureState.swift
@@ -2,6 +2,7 @@ import Foundation
 import SwiftUI
 
 public struct SliderGestureState: Equatable {
+    var speed: Float?
     private var lastOffset: CGFloat
     private var accumulations: [Float:CGFloat] = [1: 0]
 
@@ -18,6 +19,8 @@ public struct SliderGestureState: Equatable {
 
     func updating(with offset: CGFloat, speed: Float) -> Self {
         var mutSelf = self
+
+        mutSelf.speed = speed
 
         var accumulations = self.accumulations.reduce([:]) { (accum: [Float:CGFloat], element) in
             let (elementSpeed, elementValue) = element

--- a/Sources/Sliders/Base/SliderGestureState.swift
+++ b/Sources/Sliders/Base/SliderGestureState.swift
@@ -2,11 +2,11 @@ import Foundation
 import SwiftUI
 
 public struct SliderGestureState: Equatable {
-    enum Speed: CGFloat {
+    enum Speed: Float {
         case normal = 1
-        case half = 0.5
-        case quarter = 0.25
-        case eighth = 0.125
+        case half = 2
+        case quarter = 4
+        case eighth = 8
     }
 
     let precisionScrubbing: Bool
@@ -20,7 +20,7 @@ public struct SliderGestureState: Equatable {
     var offset: CGFloat {
         accumulations.reduce(0) { accum, tuple in
             let (speed, value) = tuple
-            let appliedValue = precisionScrubbing ? speed.rawValue * value : value
+            let appliedValue = precisionScrubbing ? value / CGFloat(speed.rawValue) : value
             return accum + appliedValue
         }
     }
@@ -31,9 +31,9 @@ public struct SliderGestureState: Equatable {
     }
 
     private func speed(crossAxisOffset: CGFloat) -> Speed {
-        if abs(crossAxisOffset) > 200 {
+        if abs(crossAxisOffset) > 300 {
             return .eighth
-        } else if abs(crossAxisOffset) > 150 {
+        } else if abs(crossAxisOffset) > 200 {
             return .quarter
         } else if abs(crossAxisOffset) > 100 {
             return .half

--- a/Sources/Sliders/PointSlider/Styles/Rectangular/RectangularPointSliderStyle.swift
+++ b/Sources/Sliders/PointSlider/Styles/Rectangular/RectangularPointSliderStyle.swift
@@ -79,7 +79,7 @@ public struct RectangularPointSliderStyle<Track: View, Thumb: View>: PointSlider
                     )
                 )
                 .gesture(
-                    DragGesture()
+                    DragGesture(minimumDistance: 0)
                         .onChanged { gestureValue in
                             configuration.onEditingChanged(true)
 

--- a/Sources/Sliders/RangeSlider/RangeSlider.swift
+++ b/Sources/Sliders/RangeSlider/RangeSlider.swift
@@ -45,7 +45,7 @@ extension RangeSlider {
                 step: CGFloat(step),
                 distance: CGFloat(distance.lowerBound) ... CGFloat(distance.upperBound),
                 onEditingChanged: onEditingChanged,
-                precisionScrubbing: { _ in 1 },
+                precisionScrubbing: PrecisionScrubbingKey.defaultValue,
                 dragOffset: .constant(0),
                 lowerGestureState: .init(initialValue: nil),
                 upperGestureState: .init(initialValue: nil)
@@ -72,7 +72,7 @@ extension RangeSlider {
                 step: CGFloat(step),
                 distance: CGFloat(distance.lowerBound) ... CGFloat(distance.upperBound),
                 onEditingChanged: onEditingChanged,
-                precisionScrubbing: { _ in 1 },
+                precisionScrubbing: PrecisionScrubbingKey.defaultValue,
                 dragOffset: .constant(0),
                 lowerGestureState: .init(initialValue: nil),
                 upperGestureState: .init(initialValue: nil)

--- a/Sources/Sliders/RangeSlider/RangeSlider.swift
+++ b/Sources/Sliders/RangeSlider/RangeSlider.swift
@@ -3,12 +3,18 @@ import SwiftUI
 public struct RangeSlider: View {
     @Environment(\.rangeSliderStyle) private var style
     @State private var dragOffset: CGFloat?
+    @GestureState private var lowerGestureState: SliderGestureState?
+    @GestureState private var upperGestureState: SliderGestureState?
     
     private var configuration: RangeSliderStyleConfiguration
     
     public var body: some View {
         self.style.makeBody(configuration:
-            self.configuration.with(dragOffset: self.$dragOffset)
+            self.configuration.with(
+                dragOffset: self.$dragOffset,
+                lowerGestureState: self.$lowerGestureState,
+                upperGestureState: self.$upperGestureState
+            )
         )
     }
 }
@@ -37,7 +43,9 @@ extension RangeSlider {
                 step: CGFloat(step),
                 distance: CGFloat(distance.lowerBound) ... CGFloat(distance.upperBound),
                 onEditingChanged: onEditingChanged,
-                dragOffset: .constant(0)
+                dragOffset: .constant(0),
+                lowerGestureState: .init(initialValue: nil),
+                upperGestureState: .init(initialValue: nil)
             )
         )
     }
@@ -61,7 +69,9 @@ extension RangeSlider {
                 step: CGFloat(step),
                 distance: CGFloat(distance.lowerBound) ... CGFloat(distance.upperBound),
                 onEditingChanged: onEditingChanged,
-                dragOffset: .constant(0)
+                dragOffset: .constant(0),
+                lowerGestureState: .init(initialValue: nil),
+                upperGestureState: .init(initialValue: nil)
             )
         )
     }

--- a/Sources/Sliders/RangeSlider/RangeSlider.swift
+++ b/Sources/Sliders/RangeSlider/RangeSlider.swift
@@ -31,7 +31,8 @@ extension RangeSlider {
         in bounds: ClosedRange<V> = 0.0...1.0,
         step: V.Stride = 0.001,
         distance: ClosedRange<V> = 0.0 ... .infinity,
-        onEditingChanged: @escaping (Bool) -> Void = { _ in }
+        onEditingChanged: @escaping (Bool) -> Void = { _ in },
+        onPrecisionScrubbingChange: @escaping (Float?) -> Void = { _ in }
     ) where V : BinaryFloatingPoint, V.Stride : BinaryFloatingPoint {
         self.init(
             RangeSliderStyleConfiguration(
@@ -43,6 +44,7 @@ extension RangeSlider {
                 step: CGFloat(step),
                 distance: CGFloat(distance.lowerBound) ... CGFloat(distance.upperBound),
                 onEditingChanged: onEditingChanged,
+                onPrecisionScrubbingChange: onPrecisionScrubbingChange,
                 dragOffset: .constant(0),
                 lowerGestureState: .init(initialValue: nil),
                 upperGestureState: .init(initialValue: nil)
@@ -57,7 +59,8 @@ extension RangeSlider {
         in bounds: ClosedRange<V> = 0...1,
         step: V.Stride = 1,
         distance: ClosedRange<V> = 0 ... .max,
-        onEditingChanged: @escaping (Bool) -> Void = { _ in }
+        onEditingChanged: @escaping (Bool) -> Void = { _ in },
+        onPrecisionScrubbingChange: @escaping (Float?) -> Void = { _ in }
     ) where V : FixedWidthInteger, V.Stride : FixedWidthInteger {
         self.init(
             RangeSliderStyleConfiguration(
@@ -69,6 +72,7 @@ extension RangeSlider {
                 step: CGFloat(step),
                 distance: CGFloat(distance.lowerBound) ... CGFloat(distance.upperBound),
                 onEditingChanged: onEditingChanged,
+                onPrecisionScrubbingChange: onPrecisionScrubbingChange,
                 dragOffset: .constant(0),
                 lowerGestureState: .init(initialValue: nil),
                 upperGestureState: .init(initialValue: nil)

--- a/Sources/Sliders/RangeSlider/RangeSlider.swift
+++ b/Sources/Sliders/RangeSlider/RangeSlider.swift
@@ -3,6 +3,7 @@ import SwiftUI
 public struct RangeSlider: View {
     @Environment(\.rangeSliderStyle) private var style
     @State private var dragOffset: CGFloat?
+    @Environment(\.precisionScrubbing) private var precisionScrubbing
     @GestureState private var lowerGestureState: SliderGestureState?
     @GestureState private var upperGestureState: SliderGestureState?
     
@@ -11,6 +12,7 @@ public struct RangeSlider: View {
     public var body: some View {
         self.style.makeBody(configuration:
             self.configuration.with(
+                precisionScrubbing: self.precisionScrubbing,
                 dragOffset: self.$dragOffset,
                 lowerGestureState: self.$lowerGestureState,
                 upperGestureState: self.$upperGestureState
@@ -31,8 +33,7 @@ extension RangeSlider {
         in bounds: ClosedRange<V> = 0.0...1.0,
         step: V.Stride = 0.001,
         distance: ClosedRange<V> = 0.0 ... .infinity,
-        onEditingChanged: @escaping (Bool) -> Void = { _ in },
-        onPrecisionScrubbingChange: @escaping (Float?) -> Void = { _ in }
+        onEditingChanged: @escaping (Bool) -> Void = { _ in }
     ) where V : BinaryFloatingPoint, V.Stride : BinaryFloatingPoint {
         self.init(
             RangeSliderStyleConfiguration(
@@ -44,7 +45,7 @@ extension RangeSlider {
                 step: CGFloat(step),
                 distance: CGFloat(distance.lowerBound) ... CGFloat(distance.upperBound),
                 onEditingChanged: onEditingChanged,
-                onPrecisionScrubbingChange: onPrecisionScrubbingChange,
+                precisionScrubbing: { _ in 1 },
                 dragOffset: .constant(0),
                 lowerGestureState: .init(initialValue: nil),
                 upperGestureState: .init(initialValue: nil)
@@ -59,8 +60,7 @@ extension RangeSlider {
         in bounds: ClosedRange<V> = 0...1,
         step: V.Stride = 1,
         distance: ClosedRange<V> = 0 ... .max,
-        onEditingChanged: @escaping (Bool) -> Void = { _ in },
-        onPrecisionScrubbingChange: @escaping (Float?) -> Void = { _ in }
+        onEditingChanged: @escaping (Bool) -> Void = { _ in }
     ) where V : FixedWidthInteger, V.Stride : FixedWidthInteger {
         self.init(
             RangeSliderStyleConfiguration(
@@ -72,7 +72,7 @@ extension RangeSlider {
                 step: CGFloat(step),
                 distance: CGFloat(distance.lowerBound) ... CGFloat(distance.upperBound),
                 onEditingChanged: onEditingChanged,
-                onPrecisionScrubbingChange: onPrecisionScrubbingChange,
+                precisionScrubbing: { _ in 1 },
                 dragOffset: .constant(0),
                 lowerGestureState: .init(initialValue: nil),
                 upperGestureState: .init(initialValue: nil)

--- a/Sources/Sliders/RangeSlider/RangeSlider.swift
+++ b/Sources/Sliders/RangeSlider/RangeSlider.swift
@@ -33,7 +33,7 @@ extension RangeSlider {
         in bounds: ClosedRange<V> = 0.0...1.0,
         step: V.Stride = 0.001,
         distance: ClosedRange<V> = 0.0 ... .infinity,
-        onEditingChanged: @escaping (Bool) -> Void = { _ in }
+        onEditingChanged: @escaping (EditingRange) -> Void = { _ in }
     ) where V : BinaryFloatingPoint, V.Stride : BinaryFloatingPoint {
         self.init(
             RangeSliderStyleConfiguration(
@@ -60,7 +60,7 @@ extension RangeSlider {
         in bounds: ClosedRange<V> = 0...1,
         step: V.Stride = 1,
         distance: ClosedRange<V> = 0 ... .max,
-        onEditingChanged: @escaping (Bool) -> Void = { _ in }
+        onEditingChanged: @escaping (EditingRange) -> Void = { _ in }
     ) where V : FixedWidthInteger, V.Stride : FixedWidthInteger {
         self.init(
             RangeSliderStyleConfiguration(

--- a/Sources/Sliders/RangeSlider/Style/RangeSliderStyleConfiguration.swift
+++ b/Sources/Sliders/RangeSlider/Style/RangeSliderStyleConfiguration.swift
@@ -6,13 +6,14 @@ public struct RangeSliderStyleConfiguration {
     public let step: CGFloat
     public let distance: ClosedRange<CGFloat>
     public let onEditingChanged: (Bool) -> Void
-    public let onPrecisionScrubbingChange: (Float?) -> Void
+    public var precisionScrubbing: (Float) -> Float
     public var dragOffset: Binding<CGFloat?>
     public var lowerGestureState: GestureState<SliderGestureState?>
     public var upperGestureState: GestureState<SliderGestureState?>
     
-    func with(dragOffset: Binding<CGFloat?>, lowerGestureState: GestureState<SliderGestureState?>, upperGestureState: GestureState<SliderGestureState?>) -> Self {
+    func with(precisionScrubbing: @escaping (Float) -> Float, dragOffset: Binding<CGFloat?>, lowerGestureState: GestureState<SliderGestureState?>, upperGestureState: GestureState<SliderGestureState?>) -> Self {
         var mutSelf = self
+        mutSelf.precisionScrubbing = precisionScrubbing
         mutSelf.dragOffset = dragOffset
         mutSelf.lowerGestureState = lowerGestureState
         mutSelf.upperGestureState = upperGestureState

--- a/Sources/Sliders/RangeSlider/Style/RangeSliderStyleConfiguration.swift
+++ b/Sources/Sliders/RangeSlider/Style/RangeSliderStyleConfiguration.swift
@@ -7,10 +7,14 @@ public struct RangeSliderStyleConfiguration {
     public let distance: ClosedRange<CGFloat>
     public let onEditingChanged: (Bool) -> Void
     public var dragOffset: Binding<CGFloat?>
+    public var lowerGestureState: GestureState<SliderGestureState?>
+    public var upperGestureState: GestureState<SliderGestureState?>
     
-    func with(dragOffset: Binding<CGFloat?>) -> Self {
+    func with(dragOffset: Binding<CGFloat?>, lowerGestureState: GestureState<SliderGestureState?>, upperGestureState: GestureState<SliderGestureState?>) -> Self {
         var mutSelf = self
         mutSelf.dragOffset = dragOffset
+        mutSelf.lowerGestureState = lowerGestureState
+        mutSelf.upperGestureState = upperGestureState
         return mutSelf
     }
 }

--- a/Sources/Sliders/RangeSlider/Style/RangeSliderStyleConfiguration.swift
+++ b/Sources/Sliders/RangeSlider/Style/RangeSliderStyleConfiguration.swift
@@ -5,7 +5,7 @@ public struct RangeSliderStyleConfiguration {
     public let bounds: ClosedRange<CGFloat>
     public let step: CGFloat
     public let distance: ClosedRange<CGFloat>
-    public let onEditingChanged: (Bool) -> Void
+    public let onEditingChanged: (EditingRange) -> Void
     public var precisionScrubbing: PrecisionScrubbingConfig
     public var dragOffset: Binding<CGFloat?>
     public var lowerGestureState: GestureState<SliderGestureState?>

--- a/Sources/Sliders/RangeSlider/Style/RangeSliderStyleConfiguration.swift
+++ b/Sources/Sliders/RangeSlider/Style/RangeSliderStyleConfiguration.swift
@@ -6,12 +6,12 @@ public struct RangeSliderStyleConfiguration {
     public let step: CGFloat
     public let distance: ClosedRange<CGFloat>
     public let onEditingChanged: (Bool) -> Void
-    public var precisionScrubbing: (Float) -> Float
+    public var precisionScrubbing: PrecisionScrubbingConfig
     public var dragOffset: Binding<CGFloat?>
     public var lowerGestureState: GestureState<SliderGestureState?>
     public var upperGestureState: GestureState<SliderGestureState?>
     
-    func with(precisionScrubbing: @escaping (Float) -> Float, dragOffset: Binding<CGFloat?>, lowerGestureState: GestureState<SliderGestureState?>, upperGestureState: GestureState<SliderGestureState?>) -> Self {
+    func with(precisionScrubbing: PrecisionScrubbingConfig, dragOffset: Binding<CGFloat?>, lowerGestureState: GestureState<SliderGestureState?>, upperGestureState: GestureState<SliderGestureState?>) -> Self {
         var mutSelf = self
         mutSelf.precisionScrubbing = precisionScrubbing
         mutSelf.dragOffset = dragOffset

--- a/Sources/Sliders/RangeSlider/Style/RangeSliderStyleConfiguration.swift
+++ b/Sources/Sliders/RangeSlider/Style/RangeSliderStyleConfiguration.swift
@@ -6,6 +6,7 @@ public struct RangeSliderStyleConfiguration {
     public let step: CGFloat
     public let distance: ClosedRange<CGFloat>
     public let onEditingChanged: (Bool) -> Void
+    public let onPrecisionScrubbingChange: (Float?) -> Void
     public var dragOffset: Binding<CGFloat?>
     public var lowerGestureState: GestureState<SliderGestureState?>
     public var upperGestureState: GestureState<SliderGestureState?>

--- a/Sources/Sliders/RangeSlider/Styles/Horizontal/HorizontalRangeSliderStyle.swift
+++ b/Sources/Sliders/RangeSlider/Styles/Horizontal/HorizontalRangeSliderStyle.swift
@@ -47,7 +47,7 @@ public struct HorizontalRangeSliderStyle<Track: View, LowerThumb: View, UpperThu
                 )
                 .gesture(
                     SimultaneousGesture(
-                        DragGesture()
+                        DragGesture(minimumDistance: 0)
                             .onChanged { gestureValue in
                                 configuration.onEditingChanged(true)
 
@@ -108,7 +108,7 @@ public struct HorizontalRangeSliderStyle<Track: View, LowerThumb: View, UpperThu
                 )
                 .gesture(
                     SimultaneousGesture(
-                        DragGesture()
+                        DragGesture(minimumDistance: 0)
                             .onChanged { gestureValue in
                                 configuration.onEditingChanged(true)
 

--- a/Sources/Sliders/RangeSlider/Styles/Horizontal/HorizontalRangeSliderStyle.swift
+++ b/Sources/Sliders/RangeSlider/Styles/Horizontal/HorizontalRangeSliderStyle.swift
@@ -160,7 +160,7 @@ public struct HorizontalRangeSliderStyle<Track: View, LowerThumb: View, UpperThu
                     forceAdjacent: options.contains(.forceAdjacentValue)
                 )
             }
-            .onChange(of: configuration.lowerGestureState.wrappedValue != nil || configuration.upperGestureState.wrappedValue != nil) { editing in
+            .onChange(of: editing) { editing in
                 configuration.onEditingChanged(editing)
             }
             .onChange(of: precisionScrubbingSpeed) { precisionScrubbingSpeed in

--- a/Sources/Sliders/RangeSlider/Styles/Horizontal/HorizontalRangeSliderStyle.swift
+++ b/Sources/Sliders/RangeSlider/Styles/Horizontal/HorizontalRangeSliderStyle.swift
@@ -65,13 +65,10 @@ public struct HorizontalRangeSliderStyle<Track: View, LowerThumb: View, UpperThu
                             .updating(configuration.lowerGestureState) { value, state, transaction in
                                 state = (state ?? {
                                     let x = lowerX(configuration: configuration, geometry: geometry)
-                                    return SliderGestureState(
-                                        precisionScrubbing: options.contains(.precisionScrubbing),
-                                        initialOffset: value.location.x - x
-                                    )
+                                    return SliderGestureState(initialOffset: value.location.x - x)
                                 }()).updating(
                                     with: value.location.x,
-                                    crossAxisOffset: value.translation.height
+                                    speed: configuration.precisionScrubbing(Float(value.translation.height))
                                 )
                             },
                         TapGesture()
@@ -96,13 +93,10 @@ public struct HorizontalRangeSliderStyle<Track: View, LowerThumb: View, UpperThu
                             .updating(configuration.upperGestureState) { value, state, transaction in
                                 state = (state ?? { () -> SliderGestureState in
                                     let x = upperX(configuration: configuration, geometry: geometry)
-                                    return SliderGestureState(
-                                        precisionScrubbing: options.contains(.precisionScrubbing),
-                                        initialOffset: value.location.x - x
-                                    )
+                                    return SliderGestureState(initialOffset: value.location.x - x)
                                 }()).updating(
                                     with: value.location.x,
-                                    crossAxisOffset: value.translation.height
+                                    speed: configuration.precisionScrubbing(Float(value.translation.height))
                                 )
                             },
                         TapGesture()
@@ -156,9 +150,6 @@ public struct HorizontalRangeSliderStyle<Track: View, LowerThumb: View, UpperThu
             }
             .onChange(of: configuration.lowerGestureState.wrappedValue != nil || configuration.upperGestureState.wrappedValue != nil) { editing in
                 configuration.onEditingChanged(editing)
-            }
-            .onChange(of: configuration.lowerGestureState.wrappedValue?.speed ?? configuration.upperGestureState.wrappedValue?.speed) { speed in
-                configuration.onPrecisionScrubbingChange(speed?.rawValue)
             }
         }
         .frame(minHeight: max(self.lowerThumbInteractiveSize.height, self.upperThumbInteractiveSize.height))

--- a/Sources/Sliders/RangeSlider/Styles/Horizontal/HorizontalRangeSliderStyle.swift
+++ b/Sources/Sliders/RangeSlider/Styles/Horizontal/HorizontalRangeSliderStyle.swift
@@ -157,6 +157,9 @@ public struct HorizontalRangeSliderStyle<Track: View, LowerThumb: View, UpperThu
             .onChange(of: configuration.lowerGestureState.wrappedValue != nil || configuration.upperGestureState.wrappedValue != nil) { editing in
                 configuration.onEditingChanged(editing)
             }
+            .onChange(of: configuration.lowerGestureState.wrappedValue?.speed ?? configuration.upperGestureState.wrappedValue?.speed) { speed in
+                configuration.onPrecisionScrubbingChange(speed?.rawValue)
+            }
         }
         .frame(minHeight: max(self.lowerThumbInteractiveSize.height, self.upperThumbInteractiveSize.height))
     }

--- a/Sources/Sliders/RangeSlider/Styles/Horizontal/HorizontalRangeSliderStyle.swift
+++ b/Sources/Sliders/RangeSlider/Styles/Horizontal/HorizontalRangeSliderStyle.swift
@@ -45,47 +45,50 @@ public struct HorizontalRangeSliderStyle<Track: View, LowerThumb: View, UpperThu
                     ),
                     y: geometry.size.height / 2
                 )
-                .onTapGesture {
-                    self.onSelectLower()
-                }
                 .gesture(
-                    DragGesture(minimumDistance: 0)
-                        .onChanged { gestureValue in
-                            configuration.onEditingChanged(true)
+                    SimultaneousGesture(
+                        DragGesture()
+                            .onChanged { gestureValue in
+                                configuration.onEditingChanged(true)
 
-                            self.onSelectLower()
+                                self.onSelectLower()
 
-                            if configuration.dragOffset.wrappedValue == nil {
-                                configuration.dragOffset.wrappedValue = gestureValue.startLocation.x - distanceFrom(
-                                    value: configuration.range.wrappedValue.lowerBound,
+                                if configuration.dragOffset.wrappedValue == nil {
+                                    configuration.dragOffset.wrappedValue = gestureValue.startLocation.x - distanceFrom(
+                                        value: configuration.range.wrappedValue.lowerBound,
+                                        availableDistance: geometry.size.width - self.upperThumbSize.width,
+                                        bounds: configuration.bounds,
+                                        leadingOffset: self.lowerThumbSize.width / 2,
+                                        trailingOffset: self.lowerThumbSize.width / 2
+                                    )
+                                }
+
+                                let computedLowerBound = valueFrom(
+                                    distance: gestureValue.location.x - (configuration.dragOffset.wrappedValue ?? 0),
                                     availableDistance: geometry.size.width - self.upperThumbSize.width,
                                     bounds: configuration.bounds,
+                                    step: configuration.step,
                                     leadingOffset: self.lowerThumbSize.width / 2,
                                     trailingOffset: self.lowerThumbSize.width / 2
                                 )
+
+                                configuration.range.wrappedValue = rangeFrom(
+                                    updatedLowerBound: computedLowerBound,
+                                    upperBound: configuration.range.wrappedValue.upperBound,
+                                    bounds: configuration.bounds,
+                                    distance: configuration.distance,
+                                    forceAdjacent: options.contains(.forceAdjacentValue)
+                                )
                             }
-
-                            let computedLowerBound = valueFrom(
-                                distance: gestureValue.location.x - (configuration.dragOffset.wrappedValue ?? 0),
-                                availableDistance: geometry.size.width - self.upperThumbSize.width,
-                                bounds: configuration.bounds,
-                                step: configuration.step,
-                                leadingOffset: self.lowerThumbSize.width / 2,
-                                trailingOffset: self.lowerThumbSize.width / 2
-                            )
-
-                            configuration.range.wrappedValue = rangeFrom(
-                                updatedLowerBound: computedLowerBound,
-                                upperBound: configuration.range.wrappedValue.upperBound,
-                                bounds: configuration.bounds,
-                                distance: configuration.distance,
-                                forceAdjacent: options.contains(.forceAdjacentValue)
-                            )
-                        }
-                        .onEnded { _ in
-                            configuration.dragOffset.wrappedValue = nil
-                            configuration.onEditingChanged(false)
-                        }
+                            .onEnded { _ in
+                                configuration.dragOffset.wrappedValue = nil
+                                configuration.onEditingChanged(false)
+                            },
+                        TapGesture()
+                            .onEnded { _ in
+                                self.onSelectLower()
+                            }
+                    )
                 )
 
                 ZStack {
@@ -103,47 +106,50 @@ public struct HorizontalRangeSliderStyle<Track: View, LowerThumb: View, UpperThu
                     ),
                     y: geometry.size.height / 2
                 )
-                .onTapGesture {
-                    self.onSelectUpper()
-                }
                 .gesture(
-                    DragGesture(minimumDistance: 0)
-                        .onChanged { gestureValue in
-                            configuration.onEditingChanged(true)
+                    SimultaneousGesture(
+                        DragGesture()
+                            .onChanged { gestureValue in
+                                configuration.onEditingChanged(true)
 
-                            self.onSelectUpper()
+                                self.onSelectUpper()
 
-                            if configuration.dragOffset.wrappedValue == nil {
-                                configuration.dragOffset.wrappedValue = gestureValue.startLocation.x - distanceFrom(
-                                    value: configuration.range.wrappedValue.upperBound,
+                                if configuration.dragOffset.wrappedValue == nil {
+                                    configuration.dragOffset.wrappedValue = gestureValue.startLocation.x - distanceFrom(
+                                        value: configuration.range.wrappedValue.upperBound,
+                                        availableDistance: geometry.size.width,
+                                        bounds: configuration.bounds,
+                                        leadingOffset: self.lowerThumbSize.width + self.upperThumbSize.width / 2,
+                                        trailingOffset: self.upperThumbSize.width / 2
+                                    )
+                                }
+
+                                let computedUpperBound = valueFrom(
+                                    distance: gestureValue.location.x - (configuration.dragOffset.wrappedValue ?? 0),
                                     availableDistance: geometry.size.width,
                                     bounds: configuration.bounds,
+                                    step: configuration.step,
                                     leadingOffset: self.lowerThumbSize.width + self.upperThumbSize.width / 2,
                                     trailingOffset: self.upperThumbSize.width / 2
                                 )
+
+                                configuration.range.wrappedValue = rangeFrom(
+                                    lowerBound: configuration.range.wrappedValue.lowerBound,
+                                    updatedUpperBound: computedUpperBound,
+                                    bounds: configuration.bounds,
+                                    distance: configuration.distance,
+                                    forceAdjacent: options.contains(.forceAdjacentValue)
+                                )
                             }
-
-                            let computedUpperBound = valueFrom(
-                                distance: gestureValue.location.x - (configuration.dragOffset.wrappedValue ?? 0),
-                                availableDistance: geometry.size.width,
-                                bounds: configuration.bounds,
-                                step: configuration.step,
-                                leadingOffset: self.lowerThumbSize.width + self.upperThumbSize.width / 2,
-                                trailingOffset: self.upperThumbSize.width / 2
-                            )
-
-                            configuration.range.wrappedValue = rangeFrom(
-                                lowerBound: configuration.range.wrappedValue.lowerBound,
-                                updatedUpperBound: computedUpperBound,
-                                bounds: configuration.bounds,
-                                distance: configuration.distance,
-                                forceAdjacent: options.contains(.forceAdjacentValue)
-                            )
-                        }
-                        .onEnded { _ in
-                            configuration.dragOffset.wrappedValue = nil
-                            configuration.onEditingChanged(false)
-                        }
+                            .onEnded { _ in
+                                configuration.dragOffset.wrappedValue = nil
+                                configuration.onEditingChanged(false)
+                            },
+                        TapGesture()
+                            .onEnded { _ in
+                                self.onSelectUpper()
+                            }
+                    )
                 )
 
             }

--- a/Sources/Sliders/RangeSlider/Styles/Horizontal/HorizontalRangeSliderStyle.swift
+++ b/Sources/Sliders/RangeSlider/Styles/Horizontal/HorizontalRangeSliderStyle.swift
@@ -49,7 +49,7 @@ public struct HorizontalRangeSliderStyle<Track: View, LowerThumb: View, UpperThu
                     self.onSelectLower()
                 }
                 .gesture(
-                    DragGesture()
+                    DragGesture(minimumDistance: 0)
                         .onChanged { gestureValue in
                             configuration.onEditingChanged(true)
 
@@ -73,7 +73,7 @@ public struct HorizontalRangeSliderStyle<Track: View, LowerThumb: View, UpperThu
                                 leadingOffset: self.lowerThumbSize.width / 2,
                                 trailingOffset: self.lowerThumbSize.width / 2
                             )
-                            
+
                             configuration.range.wrappedValue = rangeFrom(
                                 updatedLowerBound: computedLowerBound,
                                 upperBound: configuration.range.wrappedValue.upperBound,
@@ -107,7 +107,7 @@ public struct HorizontalRangeSliderStyle<Track: View, LowerThumb: View, UpperThu
                     self.onSelectUpper()
                 }
                 .gesture(
-                    DragGesture()
+                    DragGesture(minimumDistance: 0)
                         .onChanged { gestureValue in
                             configuration.onEditingChanged(true)
 
@@ -131,7 +131,7 @@ public struct HorizontalRangeSliderStyle<Track: View, LowerThumb: View, UpperThu
                                 leadingOffset: self.lowerThumbSize.width + self.upperThumbSize.width / 2,
                                 trailingOffset: self.upperThumbSize.width / 2
                             )
-                            
+
                             configuration.range.wrappedValue = rangeFrom(
                                 lowerBound: configuration.range.wrappedValue.lowerBound,
                                 updatedUpperBound: computedUpperBound,

--- a/Sources/Sliders/RangeSlider/Styles/Horizontal/HorizontalRangeSliderStyle.swift
+++ b/Sources/Sliders/RangeSlider/Styles/Horizontal/HorizontalRangeSliderStyle.swift
@@ -19,7 +19,7 @@ public struct HorizontalRangeSliderStyle<Track: View, LowerThumb: View, UpperThu
     private func lowerX(configuration: Self.Configuration, geometry: GeometryProxy) -> CGFloat {
         distanceFrom(
             value: configuration.range.wrappedValue.lowerBound,
-            availableDistance: geometry.size.width,
+            availableDistance: geometry.size.width - upperThumbSize.width,
             bounds: configuration.bounds,
             leadingOffset: lowerThumbSize.width / 2,
             trailingOffset: lowerThumbSize.width / 2
@@ -31,7 +31,7 @@ public struct HorizontalRangeSliderStyle<Track: View, LowerThumb: View, UpperThu
             value: configuration.range.wrappedValue.upperBound,
             availableDistance: geometry.size.width,
             bounds: configuration.bounds,
-            leadingOffset: upperThumbSize.width / 2,
+            leadingOffset: lowerThumbSize.width + upperThumbSize.width / 2,
             trailingOffset: upperThumbSize.width / 2
         )
     }
@@ -142,7 +142,7 @@ public struct HorizontalRangeSliderStyle<Track: View, LowerThumb: View, UpperThu
                     availableDistance: geometry.size.width,
                     bounds: configuration.bounds,
                     step: configuration.step,
-                    leadingOffset: upperThumbSize.width / 2,
+                    leadingOffset: lowerThumbSize.width + upperThumbSize.width / 2,
                     trailingOffset: upperThumbSize.width / 2
                 )
 

--- a/Sources/Sliders/RangeSlider/Styles/RangeSliderOptions.swift
+++ b/Sources/Sliders/RangeSlider/Styles/RangeSliderOptions.swift
@@ -3,7 +3,8 @@ import SwiftUI
 public struct RangeSliderOptions: OptionSet {
     public let rawValue: Int
 
-    public static let forceAdjacentValue = RangeSliderOptions(rawValue: 1 << 0)
+    public static let precisionScrubbing = RangeSliderOptions(rawValue: 1 << 0)
+    public static let forceAdjacentValue = RangeSliderOptions(rawValue: 1 << 1)
     public static let defaultOptions: RangeSliderOptions = .forceAdjacentValue
     
     public init(rawValue: Int) {

--- a/Sources/Sliders/RangeSlider/Styles/RangeSliderOptions.swift
+++ b/Sources/Sliders/RangeSlider/Styles/RangeSliderOptions.swift
@@ -3,8 +3,7 @@ import SwiftUI
 public struct RangeSliderOptions: OptionSet {
     public let rawValue: Int
 
-    public static let precisionScrubbing = RangeSliderOptions(rawValue: 1 << 0)
-    public static let forceAdjacentValue = RangeSliderOptions(rawValue: 1 << 1)
+    public static let forceAdjacentValue = RangeSliderOptions(rawValue: 1 << 0)
     public static let defaultOptions: RangeSliderOptions = .forceAdjacentValue
     
     public init(rawValue: Int) {

--- a/Sources/Sliders/RangeSlider/Styles/RangeSliderOptions.swift
+++ b/Sources/Sliders/RangeSlider/Styles/RangeSliderOptions.swift
@@ -4,6 +4,7 @@ public struct RangeSliderOptions: OptionSet {
     public let rawValue: Int
 
     public static let forceAdjacentValue = RangeSliderOptions(rawValue: 1 << 0)
+    public static let fullBleedTrack = RangeSliderOptions(rawValue: 1 << 1)
     public static let defaultOptions: RangeSliderOptions = .forceAdjacentValue
     
     public init(rawValue: Int) {

--- a/Sources/Sliders/RangeSlider/Styles/Vertical/VerticalRangeSliderStyle.swift
+++ b/Sources/Sliders/RangeSlider/Styles/Vertical/VerticalRangeSliderStyle.swift
@@ -43,7 +43,7 @@ public struct VerticalRangeSliderStyle<Track: View, LowerThumb: View, UpperThumb
                     )
                 )
                 .gesture(
-                    DragGesture()
+                    DragGesture(minimumDistance: 0)
                         .onChanged { gestureValue in
                             configuration.onEditingChanged(true)
 
@@ -65,7 +65,7 @@ public struct VerticalRangeSliderStyle<Track: View, LowerThumb: View, UpperThumb
                                 leadingOffset: self.lowerThumbSize.height / 2,
                                 trailingOffset: self.lowerThumbSize.height / 2
                             )
-                            
+
                             configuration.range.wrappedValue = rangeFrom(
                                 updatedLowerBound: computedLowerBound,
                                 upperBound: configuration.range.wrappedValue.upperBound,
@@ -96,7 +96,7 @@ public struct VerticalRangeSliderStyle<Track: View, LowerThumb: View, UpperThumb
                     )
                 )
                 .gesture(
-                    DragGesture()
+                    DragGesture(minimumDistance: 0)
                         .onChanged { gestureValue in
                             configuration.onEditingChanged(true)
 
@@ -118,7 +118,7 @@ public struct VerticalRangeSliderStyle<Track: View, LowerThumb: View, UpperThumb
                                 leadingOffset: self.lowerThumbSize.height + self.upperThumbSize.height / 2,
                                 trailingOffset: self.upperThumbSize.height / 2
                             )
-                            
+
                             configuration.range.wrappedValue = rangeFrom(
                                 lowerBound: configuration.range.wrappedValue.lowerBound,
                                 updatedUpperBound: computedUpperBound,

--- a/Sources/Sliders/RangeSlider/Styles/Vertical/VerticalRangeSliderStyle.swift
+++ b/Sources/Sliders/RangeSlider/Styles/Vertical/VerticalRangeSliderStyle.swift
@@ -45,7 +45,7 @@ public struct VerticalRangeSliderStyle<Track: View, LowerThumb: View, UpperThumb
                 .gesture(
                     DragGesture(minimumDistance: 0)
                         .onChanged { gestureValue in
-                            configuration.onEditingChanged(true)
+                            configuration.onEditingChanged(.lower)
 
                             if configuration.dragOffset.wrappedValue == nil {
                                 configuration.dragOffset.wrappedValue = gestureValue.startLocation.y - (geometry.size.height - distanceFrom(
@@ -76,7 +76,8 @@ public struct VerticalRangeSliderStyle<Track: View, LowerThumb: View, UpperThumb
                         }
                         .onEnded { _ in
                             configuration.dragOffset.wrappedValue = nil
-                            configuration.onEditingChanged(false)
+                            let upper = configuration.upperGestureState.wrappedValue != nil
+                            configuration.onEditingChanged(upper ? .upper : [])
                         }
                 )
 
@@ -98,7 +99,7 @@ public struct VerticalRangeSliderStyle<Track: View, LowerThumb: View, UpperThumb
                 .gesture(
                     DragGesture(minimumDistance: 0)
                         .onChanged { gestureValue in
-                            configuration.onEditingChanged(true)
+                            configuration.onEditingChanged(.upper)
 
                             if configuration.dragOffset.wrappedValue == nil {
                                 configuration.dragOffset.wrappedValue = gestureValue.startLocation.y - (geometry.size.height - distanceFrom(
@@ -129,7 +130,8 @@ public struct VerticalRangeSliderStyle<Track: View, LowerThumb: View, UpperThumb
                         }
                         .onEnded { _ in
                             configuration.dragOffset.wrappedValue = nil
-                            configuration.onEditingChanged(false)
+                            let lower = configuration.lowerGestureState.wrappedValue != nil
+                            configuration.onEditingChanged(lower ? .lower : [])
                         }
                 )
 

--- a/Sources/Sliders/ValueSlider/Style/ValueSliderStyleConfiguration.swift
+++ b/Sources/Sliders/ValueSlider/Style/ValueSliderStyleConfiguration.swift
@@ -6,18 +6,21 @@ public struct ValueSliderStyleConfiguration {
     public let step: CGFloat
     public let onEditingChanged: (Bool) -> Void
     public var dragOffset: Binding<CGFloat?>
+    public var gestureState: GestureState<SliderGestureState?>
     
-    public init(value: Binding<CGFloat>, bounds: ClosedRange<CGFloat>, step: CGFloat, onEditingChanged: @escaping (Bool) -> Void, dragOffset: Binding<CGFloat?>) {
+    public init(value: Binding<CGFloat>, bounds: ClosedRange<CGFloat>, step: CGFloat, onEditingChanged: @escaping (Bool) -> Void, dragOffset: Binding<CGFloat?>, gestureState: GestureState<SliderGestureState?>) {
         self.value = value
         self.bounds = bounds
         self.step = step
         self.onEditingChanged = onEditingChanged
         self.dragOffset = dragOffset
+        self.gestureState = gestureState
     }
     
-    func with(dragOffset: Binding<CGFloat?>) -> Self {
+    func with(dragOffset: Binding<CGFloat?>, gestureState: GestureState<SliderGestureState?>) -> Self {
         var mutSelf = self
         mutSelf.dragOffset = dragOffset
+        mutSelf.gestureState = gestureState
         return mutSelf
     }
 }

--- a/Sources/Sliders/ValueSlider/Style/ValueSliderStyleConfiguration.swift
+++ b/Sources/Sliders/ValueSlider/Style/ValueSliderStyleConfiguration.swift
@@ -7,7 +7,8 @@ public struct ValueSliderStyleConfiguration {
     public let onEditingChanged: (Bool) -> Void
     public var precisionScrubbing: PrecisionScrubbingConfig
     public var dragOffset: Binding<CGFloat?>
-    public var gestureState: GestureState<SliderGestureState?>
+    public var thumbGestureState: GestureState<SliderGestureState?>
+    public var trackGestureState: GestureState<SliderGestureState?>
     
     public init(
         value: Binding<CGFloat>,
@@ -16,7 +17,8 @@ public struct ValueSliderStyleConfiguration {
         onEditingChanged: @escaping (Bool) -> Void,
         precisionScrubbing: PrecisionScrubbingConfig,
         dragOffset: Binding<CGFloat?>,
-        gestureState: GestureState<SliderGestureState?>
+        thumbGestureState: GestureState<SliderGestureState?>,
+        trackGestureState: GestureState<SliderGestureState?>
     ) {
         self.value = value
         self.bounds = bounds
@@ -24,14 +26,21 @@ public struct ValueSliderStyleConfiguration {
         self.onEditingChanged = onEditingChanged
         self.precisionScrubbing = precisionScrubbing
         self.dragOffset = dragOffset
-        self.gestureState = gestureState
+        self.thumbGestureState = thumbGestureState
+        self.trackGestureState = trackGestureState
     }
     
-    func with(precisionScrubbing: PrecisionScrubbingConfig, dragOffset: Binding<CGFloat?>, gestureState: GestureState<SliderGestureState?>) -> Self {
+    func with(
+        precisionScrubbing: PrecisionScrubbingConfig,
+        dragOffset: Binding<CGFloat?>,
+        thumbGestureState: GestureState<SliderGestureState?>,
+        trackGestureState: GestureState<SliderGestureState?>
+    ) -> Self {
         var mutSelf = self
         mutSelf.precisionScrubbing = precisionScrubbing
         mutSelf.dragOffset = dragOffset
-        mutSelf.gestureState = gestureState
+        mutSelf.thumbGestureState = thumbGestureState
+        mutSelf.trackGestureState = trackGestureState
         return mutSelf
     }
 }

--- a/Sources/Sliders/ValueSlider/Style/ValueSliderStyleConfiguration.swift
+++ b/Sources/Sliders/ValueSlider/Style/ValueSliderStyleConfiguration.swift
@@ -5,7 +5,7 @@ public struct ValueSliderStyleConfiguration {
     public let bounds: ClosedRange<CGFloat>
     public let step: CGFloat
     public let onEditingChanged: (Bool) -> Void
-    public let onPrecisionScrubbingChange: (Float?) -> Void
+    public var precisionScrubbing: (Float) -> Float
     public var dragOffset: Binding<CGFloat?>
     public var gestureState: GestureState<SliderGestureState?>
     
@@ -14,7 +14,7 @@ public struct ValueSliderStyleConfiguration {
         bounds: ClosedRange<CGFloat>,
         step: CGFloat,
         onEditingChanged: @escaping (Bool) -> Void,
-        onPrecisionScrubbingChange: @escaping (Float?) -> Void,
+        precisionScrubbing: @escaping (Float) -> Float,
         dragOffset: Binding<CGFloat?>,
         gestureState: GestureState<SliderGestureState?>
     ) {
@@ -22,13 +22,14 @@ public struct ValueSliderStyleConfiguration {
         self.bounds = bounds
         self.step = step
         self.onEditingChanged = onEditingChanged
-        self.onPrecisionScrubbingChange = onPrecisionScrubbingChange
+        self.precisionScrubbing = precisionScrubbing
         self.dragOffset = dragOffset
         self.gestureState = gestureState
     }
     
-    func with(dragOffset: Binding<CGFloat?>, gestureState: GestureState<SliderGestureState?>) -> Self {
+    func with(precisionScrubbing: @escaping (Float) -> Float, dragOffset: Binding<CGFloat?>, gestureState: GestureState<SliderGestureState?>) -> Self {
         var mutSelf = self
+        mutSelf.precisionScrubbing = precisionScrubbing
         mutSelf.dragOffset = dragOffset
         mutSelf.gestureState = gestureState
         return mutSelf

--- a/Sources/Sliders/ValueSlider/Style/ValueSliderStyleConfiguration.swift
+++ b/Sources/Sliders/ValueSlider/Style/ValueSliderStyleConfiguration.swift
@@ -5,7 +5,7 @@ public struct ValueSliderStyleConfiguration {
     public let bounds: ClosedRange<CGFloat>
     public let step: CGFloat
     public let onEditingChanged: (Bool) -> Void
-    public var precisionScrubbing: (Float) -> Float
+    public var precisionScrubbing: PrecisionScrubbingConfig
     public var dragOffset: Binding<CGFloat?>
     public var gestureState: GestureState<SliderGestureState?>
     
@@ -14,7 +14,7 @@ public struct ValueSliderStyleConfiguration {
         bounds: ClosedRange<CGFloat>,
         step: CGFloat,
         onEditingChanged: @escaping (Bool) -> Void,
-        precisionScrubbing: @escaping (Float) -> Float,
+        precisionScrubbing: PrecisionScrubbingConfig,
         dragOffset: Binding<CGFloat?>,
         gestureState: GestureState<SliderGestureState?>
     ) {
@@ -27,7 +27,7 @@ public struct ValueSliderStyleConfiguration {
         self.gestureState = gestureState
     }
     
-    func with(precisionScrubbing: @escaping (Float) -> Float, dragOffset: Binding<CGFloat?>, gestureState: GestureState<SliderGestureState?>) -> Self {
+    func with(precisionScrubbing: PrecisionScrubbingConfig, dragOffset: Binding<CGFloat?>, gestureState: GestureState<SliderGestureState?>) -> Self {
         var mutSelf = self
         mutSelf.precisionScrubbing = precisionScrubbing
         mutSelf.dragOffset = dragOffset

--- a/Sources/Sliders/ValueSlider/Style/ValueSliderStyleConfiguration.swift
+++ b/Sources/Sliders/ValueSlider/Style/ValueSliderStyleConfiguration.swift
@@ -5,14 +5,24 @@ public struct ValueSliderStyleConfiguration {
     public let bounds: ClosedRange<CGFloat>
     public let step: CGFloat
     public let onEditingChanged: (Bool) -> Void
+    public let onPrecisionScrubbingChange: (Float?) -> Void
     public var dragOffset: Binding<CGFloat?>
     public var gestureState: GestureState<SliderGestureState?>
     
-    public init(value: Binding<CGFloat>, bounds: ClosedRange<CGFloat>, step: CGFloat, onEditingChanged: @escaping (Bool) -> Void, dragOffset: Binding<CGFloat?>, gestureState: GestureState<SliderGestureState?>) {
+    public init(
+        value: Binding<CGFloat>,
+        bounds: ClosedRange<CGFloat>,
+        step: CGFloat,
+        onEditingChanged: @escaping (Bool) -> Void,
+        onPrecisionScrubbingChange: @escaping (Float?) -> Void,
+        dragOffset: Binding<CGFloat?>,
+        gestureState: GestureState<SliderGestureState?>
+    ) {
         self.value = value
         self.bounds = bounds
         self.step = step
         self.onEditingChanged = onEditingChanged
+        self.onPrecisionScrubbingChange = onPrecisionScrubbingChange
         self.dragOffset = dragOffset
         self.gestureState = gestureState
     }

--- a/Sources/Sliders/ValueSlider/Styles/Horizontal/HorizontalValueSliderStyle.swift
+++ b/Sources/Sliders/ValueSlider/Styles/Horizontal/HorizontalValueSliderStyle.swift
@@ -89,6 +89,9 @@ public struct HorizontalValueSliderStyle<Track: View, Thumb: View>: ValueSliderS
             .onChange(of: configuration.gestureState.wrappedValue != nil) { editing in
                 configuration.onEditingChanged(editing)
             }
+            .onChange(of: configuration.gestureState.wrappedValue?.speed) { speed in
+                configuration.onPrecisionScrubbingChange(speed?.rawValue)
+            }
         }
         .frame(minHeight: self.thumbInteractiveSize.height)
     }

--- a/Sources/Sliders/ValueSlider/Styles/Horizontal/HorizontalValueSliderStyle.swift
+++ b/Sources/Sliders/ValueSlider/Styles/Horizontal/HorizontalValueSliderStyle.swift
@@ -33,14 +33,9 @@ public struct HorizontalValueSliderStyle<Track: View, Thumb: View>: ValueSliderS
                     track.gesture(
                         DragGesture(minimumDistance: 0)
                             .updating(configuration.gestureState) { value, state, transaction in
-                                state = (state ?? {
-                                    SliderGestureState(
-                                        precisionScrubbing: options.contains(.precisionScrubbing),
-                                        initialOffset: 0
-                                    )
-                                }()).updating(
+                                state = (state ?? SliderGestureState(initialOffset: 0)).updating(
                                     with: value.location.x,
-                                    crossAxisOffset: value.translation.height
+                                    speed: configuration.precisionScrubbing(Float(value.translation.height))
                                 )
                             }
                     )
@@ -62,13 +57,10 @@ public struct HorizontalValueSliderStyle<Track: View, Thumb: View>: ValueSliderS
                         .updating(configuration.gestureState) { value, state, transaction in
                             state = (state ?? {
                                 let x = x(configuration: configuration, geometry: geometry)
-                                return SliderGestureState(
-                                    precisionScrubbing: options.contains(.precisionScrubbing),
-                                    initialOffset: value.location.x - x
-                                )
+                                return SliderGestureState(initialOffset: value.location.x - x)
                             }()).updating(
                                 with: value.location.x,
-                                crossAxisOffset: value.translation.height
+                                speed: configuration.precisionScrubbing(Float(value.translation.height))
                             )
                         }
                 )
@@ -88,9 +80,6 @@ public struct HorizontalValueSliderStyle<Track: View, Thumb: View>: ValueSliderS
             }
             .onChange(of: configuration.gestureState.wrappedValue != nil) { editing in
                 configuration.onEditingChanged(editing)
-            }
-            .onChange(of: configuration.gestureState.wrappedValue?.speed) { speed in
-                configuration.onPrecisionScrubbingChange(speed?.rawValue)
             }
         }
         .frame(minHeight: self.thumbInteractiveSize.height)

--- a/Sources/Sliders/ValueSlider/Styles/Horizontal/HorizontalValueSliderStyle.swift
+++ b/Sources/Sliders/ValueSlider/Styles/Horizontal/HorizontalValueSliderStyle.swift
@@ -35,7 +35,7 @@ public struct HorizontalValueSliderStyle<Track: View, Thumb: View>: ValueSliderS
                             .updating(configuration.gestureState) { value, state, transaction in
                                 state = (state ?? SliderGestureState(initialOffset: 0)).updating(
                                     with: value.location.x,
-                                    speed: configuration.precisionScrubbing(Float(value.translation.height))
+                                    speed: configuration.precisionScrubbing.scrubValue(Float(value.translation.height))
                                 )
                             }
                     )
@@ -60,7 +60,7 @@ public struct HorizontalValueSliderStyle<Track: View, Thumb: View>: ValueSliderS
                                 return SliderGestureState(initialOffset: value.location.x - x)
                             }()).updating(
                                 with: value.location.x,
-                                speed: configuration.precisionScrubbing(Float(value.translation.height))
+                                speed: configuration.precisionScrubbing.scrubValue(Float(value.translation.height))
                             )
                         }
                 )
@@ -80,6 +80,9 @@ public struct HorizontalValueSliderStyle<Track: View, Thumb: View>: ValueSliderS
             }
             .onChange(of: configuration.gestureState.wrappedValue != nil) { editing in
                 configuration.onEditingChanged(editing)
+            }
+            .onChange(of: configuration.gestureState.wrappedValue?.speed) { speed in
+                configuration.precisionScrubbing.onChange?(speed)
             }
         }
         .frame(minHeight: self.thumbInteractiveSize.height)

--- a/Sources/Sliders/ValueSlider/Styles/Horizontal/HorizontalValueSliderStyle.swift
+++ b/Sources/Sliders/ValueSlider/Styles/Horizontal/HorizontalValueSliderStyle.swift
@@ -18,6 +18,7 @@ public struct HorizontalValueSliderStyle<Track: View, Thumb: View>: ValueSliderS
     }
 
     public func makeBody(configuration: Self.Configuration) -> some View {
+        let prominentGesture = configuration.thumbGestureState.wrappedValue ?? configuration.trackGestureState.wrappedValue
         let track = self.track
             .environment(\.trackValue, configuration.value.wrappedValue)
             .environment(\.valueTrackConfiguration, ValueTrackConfiguration(
@@ -32,7 +33,7 @@ public struct HorizontalValueSliderStyle<Track: View, Thumb: View>: ValueSliderS
                 if self.options.contains(.interactiveTrack) {
                     track.gesture(
                         DragGesture(minimumDistance: 0)
-                            .updating(configuration.gestureState) { value, state, transaction in
+                            .updating(configuration.trackGestureState) { value, state, transaction in
                                 state = (state ?? SliderGestureState(initialOffset: 0)).updating(
                                     with: value.location.x,
                                     speed: configuration.precisionScrubbing.scrubValue(Float(value.translation.height))
@@ -54,7 +55,7 @@ public struct HorizontalValueSliderStyle<Track: View, Thumb: View>: ValueSliderS
                 )
                 .gesture(
                     DragGesture(minimumDistance: 0)
-                        .updating(configuration.gestureState) { value, state, transaction in
+                        .updating(configuration.thumbGestureState) { value, state, transaction in
                             state = (state ?? {
                                 let x = x(configuration: configuration, geometry: geometry)
                                 return SliderGestureState(initialOffset: value.location.x - x)
@@ -66,7 +67,7 @@ public struct HorizontalValueSliderStyle<Track: View, Thumb: View>: ValueSliderS
                 )
             }
             .frame(height: geometry.size.height)
-            .onChange(of: configuration.gestureState.wrappedValue) { state in
+            .onChange(of: prominentGesture) { state in
                 guard let state else { return }
 
                 configuration.value.wrappedValue = valueFrom(
@@ -78,10 +79,10 @@ public struct HorizontalValueSliderStyle<Track: View, Thumb: View>: ValueSliderS
                     trailingOffset: self.thumbSize.width / 2
                 )
             }
-            .onChange(of: configuration.gestureState.wrappedValue != nil) { editing in
+            .onChange(of: prominentGesture != nil) { editing in
                 configuration.onEditingChanged(editing)
             }
-            .onChange(of: configuration.gestureState.wrappedValue?.speed) { speed in
+            .onChange(of: prominentGesture?.speed) { speed in
                 configuration.precisionScrubbing.onChange?(speed)
             }
         }

--- a/Sources/Sliders/ValueSlider/Styles/Horizontal/HorizontalValueSliderStyle.swift
+++ b/Sources/Sliders/ValueSlider/Styles/Horizontal/HorizontalValueSliderStyle.swift
@@ -19,12 +19,13 @@ public struct HorizontalValueSliderStyle<Track: View, Thumb: View>: ValueSliderS
 
     public func makeBody(configuration: Self.Configuration) -> some View {
         let prominentGesture = configuration.thumbGestureState.wrappedValue ?? configuration.trackGestureState.wrappedValue
+        let fullBleedTrack = self.options.contains(.fullBleedTrack)
         let track = self.track
             .environment(\.trackValue, configuration.value.wrappedValue)
             .environment(\.valueTrackConfiguration, ValueTrackConfiguration(
                 bounds: configuration.bounds,
-                leadingOffset: self.thumbSize.width / 2,
-                trailingOffset: self.thumbSize.width / 2)
+                leadingOffset: fullBleedTrack ? 0 : self.thumbSize.width / 2,
+                trailingOffset: fullBleedTrack ? 0 : self.thumbSize.width / 2)
             )
             .accentColor(Color.accentColor)
 

--- a/Sources/Sliders/ValueSlider/Styles/ValueSliderOptions.swift
+++ b/Sources/Sliders/ValueSlider/Styles/ValueSliderOptions.swift
@@ -4,6 +4,7 @@ public struct ValueSliderOptions: OptionSet {
     public let rawValue: Int
 
     public static let interactiveTrack = ValueSliderOptions(rawValue: 1 << 0)
+    public static let fullBleedTrack = ValueSliderOptions(rawValue: 1 << 1)
     public static let defaultOptions: ValueSliderOptions = []
     
     public init(rawValue: Int) {

--- a/Sources/Sliders/ValueSlider/Styles/ValueSliderOptions.swift
+++ b/Sources/Sliders/ValueSlider/Styles/ValueSliderOptions.swift
@@ -3,7 +3,8 @@ import SwiftUI
 public struct ValueSliderOptions: OptionSet {
     public let rawValue: Int
 
-    public static let interactiveTrack = ValueSliderOptions(rawValue: 1 << 0)
+    public static let precisionScrubbing = ValueSliderOptions(rawValue: 1 << 0)
+    public static let interactiveTrack = ValueSliderOptions(rawValue: 1 << 1)
     public static let defaultOptions: ValueSliderOptions = []
     
     public init(rawValue: Int) {

--- a/Sources/Sliders/ValueSlider/Styles/ValueSliderOptions.swift
+++ b/Sources/Sliders/ValueSlider/Styles/ValueSliderOptions.swift
@@ -3,8 +3,7 @@ import SwiftUI
 public struct ValueSliderOptions: OptionSet {
     public let rawValue: Int
 
-    public static let precisionScrubbing = ValueSliderOptions(rawValue: 1 << 0)
-    public static let interactiveTrack = ValueSliderOptions(rawValue: 1 << 1)
+    public static let interactiveTrack = ValueSliderOptions(rawValue: 1 << 0)
     public static let defaultOptions: ValueSliderOptions = []
     
     public init(rawValue: Int) {

--- a/Sources/Sliders/ValueSlider/Styles/Vertical/VerticalValueSliderStyle.swift
+++ b/Sources/Sliders/ValueSlider/Styles/Vertical/VerticalValueSliderStyle.swift
@@ -8,12 +8,13 @@ public struct VerticalValueSliderStyle<Track: View, Thumb: View>: ValueSliderSty
     private let options: ValueSliderOptions
 
     public func makeBody(configuration: Self.Configuration) -> some View {
+        let fullBleedTrack = self.options.contains(.fullBleedTrack)
         let track = self.track
             .environment(\.trackValue, configuration.value.wrappedValue)
             .environment(\.valueTrackConfiguration, ValueTrackConfiguration(
                 bounds: configuration.bounds,
-                leadingOffset: self.thumbSize.height / 2,
-                trailingOffset: self.thumbSize.height / 2)
+                leadingOffset: fullBleedTrack ? 0 : self.thumbSize.height / 2,
+                trailingOffset: fullBleedTrack ? 0 : self.thumbSize.height / 2)
             )
             .accentColor(Color.accentColor)
 

--- a/Sources/Sliders/ValueSlider/ValueSlider.swift
+++ b/Sources/Sliders/ValueSlider/ValueSlider.swift
@@ -24,14 +24,20 @@ extension ValueSlider {
 }
 
 extension ValueSlider {
-    public init<V>(value: Binding<V>, in bounds: ClosedRange<V> = 0.0...1.0, step: V.Stride = 0.001, onEditingChanged: @escaping (Bool) -> Void = { _ in }) where V : BinaryFloatingPoint, V.Stride : BinaryFloatingPoint {
-        
+    public init<V>(
+        value: Binding<V>,
+        in bounds: ClosedRange<V> = 0.0...1.0,
+        step: V.Stride = 0.001,
+        onEditingChanged: @escaping (Bool) -> Void = { _ in },
+        onPrecisionScrubbingChange: @escaping (Float?) -> Void = { _ in }
+    ) where V : BinaryFloatingPoint, V.Stride : BinaryFloatingPoint {
         self.init(
             ValueSliderStyleConfiguration(
                 value: Binding(get: { CGFloat(value.wrappedValue.clamped(to: bounds)) }, set: { value.wrappedValue = V($0) }),
                 bounds: CGFloat(bounds.lowerBound)...CGFloat(bounds.upperBound),
                 step: CGFloat(step),
                 onEditingChanged: onEditingChanged,
+                onPrecisionScrubbingChange: onPrecisionScrubbingChange,
                 dragOffset: .constant(0),
                 gestureState: .init(initialValue: nil)
             )
@@ -40,13 +46,20 @@ extension ValueSlider {
 }
 
 extension ValueSlider {
-    public init<V>(value: Binding<V>, in bounds: ClosedRange<V> = 0...1, step: V.Stride = 1, onEditingChanged: @escaping (Bool) -> Void = { _ in }) where V : FixedWidthInteger, V.Stride : FixedWidthInteger {
+    public init<V>(
+        value: Binding<V>,
+        in bounds: ClosedRange<V> = 0...1,
+        step: V.Stride = 1,
+        onEditingChanged: @escaping (Bool) -> Void = { _ in },
+        onPrecisionScrubbingChange: @escaping (Float?) -> Void = { _ in }
+    ) where V : FixedWidthInteger, V.Stride : FixedWidthInteger {
         self.init(
             ValueSliderStyleConfiguration(
                 value: Binding(get: { CGFloat(value.wrappedValue.clamped(to: bounds)) }, set: { value.wrappedValue = V($0) }),
                 bounds: CGFloat(bounds.lowerBound)...CGFloat(bounds.upperBound),
                 step: CGFloat(step),
                 onEditingChanged: onEditingChanged,
+                onPrecisionScrubbingChange: onPrecisionScrubbingChange,
                 dragOffset: .constant(0),
                 gestureState: .init(initialValue: nil)
             )
@@ -55,8 +68,13 @@ extension ValueSlider {
 }
 
 extension ValueSlider {
-    public init(value: Binding<Measurement<Unit>>, in bounds: ClosedRange<Measurement<Unit>>, step: Measurement<Unit>, onEditingChanged: @escaping (Bool) -> Void = { _ in }) {
-        
+    public init(
+        value: Binding<Measurement<Unit>>,
+        in bounds: ClosedRange<Measurement<Unit>>,
+        step: Measurement<Unit>,
+        onEditingChanged: @escaping (Bool) -> Void = { _ in },
+        onPrecisionScrubbingChange: @escaping (Float?) -> Void = { _ in }
+    ) {
         self.init(
             ValueSliderStyleConfiguration(
                 value: Binding(get: {
@@ -68,6 +86,7 @@ extension ValueSlider {
                 bounds: CGFloat(bounds.lowerBound.value)...CGFloat(bounds.upperBound.value),
                 step: CGFloat(step.value),
                 onEditingChanged: onEditingChanged,
+                onPrecisionScrubbingChange: onPrecisionScrubbingChange,
                 dragOffset: .constant(0),
                 gestureState: .init(initialValue: nil)
             )

--- a/Sources/Sliders/ValueSlider/ValueSlider.swift
+++ b/Sources/Sliders/ValueSlider/ValueSlider.swift
@@ -3,12 +3,16 @@ import SwiftUI
 public struct ValueSlider: View {
     @Environment(\.valueSliderStyle) private var style
     @State private var dragOffset: CGFloat?
+    @GestureState private var gestureState: SliderGestureState?
     
     private var configuration: ValueSliderStyleConfiguration
     
     public var body: some View {
         self.style.makeBody(configuration:
-            self.configuration.with(dragOffset: self.$dragOffset)
+            self.configuration.with(
+                dragOffset: self.$dragOffset,
+                gestureState: self.$gestureState
+            )
         )
     }
 }
@@ -28,7 +32,8 @@ extension ValueSlider {
                 bounds: CGFloat(bounds.lowerBound)...CGFloat(bounds.upperBound),
                 step: CGFloat(step),
                 onEditingChanged: onEditingChanged,
-                dragOffset: .constant(0)
+                dragOffset: .constant(0),
+                gestureState: .init(initialValue: nil)
             )
         )
     }
@@ -42,7 +47,8 @@ extension ValueSlider {
                 bounds: CGFloat(bounds.lowerBound)...CGFloat(bounds.upperBound),
                 step: CGFloat(step),
                 onEditingChanged: onEditingChanged,
-                dragOffset: .constant(0)
+                dragOffset: .constant(0),
+                gestureState: .init(initialValue: nil)
             )
         )
     }
@@ -62,7 +68,8 @@ extension ValueSlider {
                 bounds: CGFloat(bounds.lowerBound.value)...CGFloat(bounds.upperBound.value),
                 step: CGFloat(step.value),
                 onEditingChanged: onEditingChanged,
-                dragOffset: .constant(0)
+                dragOffset: .constant(0),
+                gestureState: .init(initialValue: nil)
             )
         )
     }

--- a/Sources/Sliders/ValueSlider/ValueSlider.swift
+++ b/Sources/Sliders/ValueSlider/ValueSlider.swift
@@ -4,7 +4,8 @@ public struct ValueSlider: View {
     @Environment(\.valueSliderStyle) private var style
     @Environment(\.precisionScrubbing) private var precisionScrubbing
     @State private var dragOffset: CGFloat?
-    @GestureState private var gestureState: SliderGestureState?
+    @GestureState private var thumbGestureState: SliderGestureState?
+    @GestureState private var trackGestureState: SliderGestureState?
     
     private var configuration: ValueSliderStyleConfiguration
     
@@ -13,7 +14,8 @@ public struct ValueSlider: View {
             self.configuration.with(
                 precisionScrubbing: self.precisionScrubbing,
                 dragOffset: self.$dragOffset,
-                gestureState: self.$gestureState
+                thumbGestureState: self.$thumbGestureState,
+                trackGestureState: self.$trackGestureState
             )
         )
     }
@@ -40,7 +42,8 @@ extension ValueSlider {
                 onEditingChanged: onEditingChanged,
                 precisionScrubbing: PrecisionScrubbingKey.defaultValue,
                 dragOffset: .constant(0),
-                gestureState: .init(initialValue: nil)
+                thumbGestureState: .init(initialValue: nil),
+                trackGestureState: .init(initialValue: nil)
             )
         )
     }
@@ -61,7 +64,8 @@ extension ValueSlider {
                 onEditingChanged: onEditingChanged,
                 precisionScrubbing: PrecisionScrubbingKey.defaultValue,
                 dragOffset: .constant(0),
-                gestureState: .init(initialValue: nil)
+                thumbGestureState: .init(initialValue: nil),
+                trackGestureState: .init(initialValue: nil)
             )
         )
     }
@@ -87,7 +91,8 @@ extension ValueSlider {
                 onEditingChanged: onEditingChanged,
                 precisionScrubbing: PrecisionScrubbingKey.defaultValue,
                 dragOffset: .constant(0),
-                gestureState: .init(initialValue: nil)
+                thumbGestureState: .init(initialValue: nil),
+                trackGestureState: .init(initialValue: nil)
             )
         )
     }

--- a/Sources/Sliders/ValueSlider/ValueSlider.swift
+++ b/Sources/Sliders/ValueSlider/ValueSlider.swift
@@ -38,7 +38,7 @@ extension ValueSlider {
                 bounds: CGFloat(bounds.lowerBound)...CGFloat(bounds.upperBound),
                 step: CGFloat(step),
                 onEditingChanged: onEditingChanged,
-                precisionScrubbing: { _ in 1 },
+                precisionScrubbing: PrecisionScrubbingKey.defaultValue,
                 dragOffset: .constant(0),
                 gestureState: .init(initialValue: nil)
             )
@@ -59,7 +59,7 @@ extension ValueSlider {
                 bounds: CGFloat(bounds.lowerBound)...CGFloat(bounds.upperBound),
                 step: CGFloat(step),
                 onEditingChanged: onEditingChanged,
-                precisionScrubbing: { _ in 1 },
+                precisionScrubbing: PrecisionScrubbingKey.defaultValue,
                 dragOffset: .constant(0),
                 gestureState: .init(initialValue: nil)
             )
@@ -85,7 +85,7 @@ extension ValueSlider {
                 bounds: CGFloat(bounds.lowerBound.value)...CGFloat(bounds.upperBound.value),
                 step: CGFloat(step.value),
                 onEditingChanged: onEditingChanged,
-                precisionScrubbing: { _ in 1 },
+                precisionScrubbing: PrecisionScrubbingKey.defaultValue,
                 dragOffset: .constant(0),
                 gestureState: .init(initialValue: nil)
             )

--- a/Sources/Sliders/ValueSlider/ValueSlider.swift
+++ b/Sources/Sliders/ValueSlider/ValueSlider.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 public struct ValueSlider: View {
     @Environment(\.valueSliderStyle) private var style
+    @Environment(\.precisionScrubbing) private var precisionScrubbing
     @State private var dragOffset: CGFloat?
     @GestureState private var gestureState: SliderGestureState?
     
@@ -10,6 +11,7 @@ public struct ValueSlider: View {
     public var body: some View {
         self.style.makeBody(configuration:
             self.configuration.with(
+                precisionScrubbing: self.precisionScrubbing,
                 dragOffset: self.$dragOffset,
                 gestureState: self.$gestureState
             )
@@ -28,8 +30,7 @@ extension ValueSlider {
         value: Binding<V>,
         in bounds: ClosedRange<V> = 0.0...1.0,
         step: V.Stride = 0.001,
-        onEditingChanged: @escaping (Bool) -> Void = { _ in },
-        onPrecisionScrubbingChange: @escaping (Float?) -> Void = { _ in }
+        onEditingChanged: @escaping (Bool) -> Void = { _ in }
     ) where V : BinaryFloatingPoint, V.Stride : BinaryFloatingPoint {
         self.init(
             ValueSliderStyleConfiguration(
@@ -37,7 +38,7 @@ extension ValueSlider {
                 bounds: CGFloat(bounds.lowerBound)...CGFloat(bounds.upperBound),
                 step: CGFloat(step),
                 onEditingChanged: onEditingChanged,
-                onPrecisionScrubbingChange: onPrecisionScrubbingChange,
+                precisionScrubbing: { _ in 1 },
                 dragOffset: .constant(0),
                 gestureState: .init(initialValue: nil)
             )
@@ -50,8 +51,7 @@ extension ValueSlider {
         value: Binding<V>,
         in bounds: ClosedRange<V> = 0...1,
         step: V.Stride = 1,
-        onEditingChanged: @escaping (Bool) -> Void = { _ in },
-        onPrecisionScrubbingChange: @escaping (Float?) -> Void = { _ in }
+        onEditingChanged: @escaping (Bool) -> Void = { _ in }
     ) where V : FixedWidthInteger, V.Stride : FixedWidthInteger {
         self.init(
             ValueSliderStyleConfiguration(
@@ -59,7 +59,7 @@ extension ValueSlider {
                 bounds: CGFloat(bounds.lowerBound)...CGFloat(bounds.upperBound),
                 step: CGFloat(step),
                 onEditingChanged: onEditingChanged,
-                onPrecisionScrubbingChange: onPrecisionScrubbingChange,
+                precisionScrubbing: { _ in 1 },
                 dragOffset: .constant(0),
                 gestureState: .init(initialValue: nil)
             )
@@ -72,8 +72,7 @@ extension ValueSlider {
         value: Binding<Measurement<Unit>>,
         in bounds: ClosedRange<Measurement<Unit>>,
         step: Measurement<Unit>,
-        onEditingChanged: @escaping (Bool) -> Void = { _ in },
-        onPrecisionScrubbingChange: @escaping (Float?) -> Void = { _ in }
+        onEditingChanged: @escaping (Bool) -> Void = { _ in }
     ) {
         self.init(
             ValueSliderStyleConfiguration(
@@ -86,7 +85,7 @@ extension ValueSlider {
                 bounds: CGFloat(bounds.lowerBound.value)...CGFloat(bounds.upperBound.value),
                 step: CGFloat(step.value),
                 onEditingChanged: onEditingChanged,
-                onPrecisionScrubbingChange: onPrecisionScrubbingChange,
+                precisionScrubbing: { _ in 1 },
                 dragOffset: .constant(0),
                 gestureState: .init(initialValue: nil)
             )


### PR DESCRIPTION
Sets the minimum distance to 0, so fine adjustments are possible

Makes the selectUpper/selectLower gestures simultaneous so they won't delay the dragging. There might need to be some logic here to revert to the previous value if they tapped but slightly moved their thumb

Refactors some (`Horizontal{Value,Range}Slider`s) to use `@GestureState` - which properly tracks when gestures are cancelled (which `onEnd` does not do). The others need updating, but I'm lazy

Fixes simultaneous gestures when using interactive track, and putting a finger on the thumb and track

Adds `precisionScrubbing` which lets you move your finger down to slow down the scrubbing speed:-

```swift
enum ScrubbingSpeed: Float {
  case normal = 1, slow = 2
}

struct Example: View {
  var body: some View {
    yourSlider.precisionScrubbing { offset -> ScrubbingSpeed in
      if (abs(offset) > 200) {
        return .slow
      } else {
        return .normal
      }
    } onChange: { newSpeed in
      print(newSpeed) // Maybe add to the UI, play some haptics or something
    }
  }
}
```

It may look like extra ceremony declaring an enum for scrubbing speeds - and you may think you could just return a float. However - it's absolutely critical that there are a limited number of values returned for the scrubbing speed. When going from a slower to faster scrubbing speed (e.g. 8x slow down to 4x), you have to 'undo' the 8x adjustments, and apply them to the 4x. This is what happens in the iOS video player (although they managed to animate this change). This basically means storing every speed and the corresponding offset accumulations in a dictionary, and if the user could freely return any float, and they may be tempted to use linear interpolation for the speed, which would make the dictionary huge