### PR TITLE
steps should be discrete offsets from lowerBound

### DIFF
--- a/Sources/Sliders/Base/LinearValueMath.swift
+++ b/Sources/Sliders/Base/LinearValueMath.swift
@@ -16,8 +16,8 @@ import SwiftUI
 /// Example: For relative value 0.5 in range 2.0..4.0 produces 3.0
 @inlinable func valueFrom(distance: CGFloat, availableDistance: CGFloat, bounds: ClosedRange<CGFloat> = 0.0...1.0, step: CGFloat = 0.001, leadingOffset: CGFloat = 0, trailingOffset: CGFloat = 0) -> CGFloat {
     let relativeValue = (distance - leadingOffset) / (availableDistance - (leadingOffset + trailingOffset))
-    let newValue = bounds.lowerBound + (relativeValue * (bounds.upperBound - bounds.lowerBound))
-    let steppedNewValue = (round(newValue / step) * step)
+    let newValue = relativeValue * (bounds.upperBound - bounds.lowerBound)
+    let steppedNewValue = bounds.lowerBound + round(newValue / step) * step
     let validatedValue = min(bounds.upperBound, max(bounds.lowerBound, steppedNewValue))
     return validatedValue
 }


### PR DESCRIPTION
Given:

```Swift
    Slider(value: $v1, in: 1...10, step: 2, onEditingChanged: { _ in })
    Text("Slider: \(v1)")
            
    ValueSlider(value: $v2, in: 1...10, step: 2, onEditingChanged: { _ in })
        .frame(height: 30)
    Text("ValueSlider: \(v2)")
```

<img width="429" alt="Screenshot 2023-09-18 at 9 58 09 AM" src="https://github.com/spacenation/swiftui-sliders/assets/140762048/c6a6dc4f-a9b0-4ab1-a6bb-0c4668f0ae04">

Apple's `Slider()` reports the discrete values [ 1, 3, 5, 7, 9 ] while `ValueSlider()` reports [ 1, 2, 4, 6, 8, 10 ]. IOW, `Slider()`'s steps are offsets from the `lowerBound` while `ValueSlider()`'s are 0-based.

This PR changes the behavior of `step` to match `Slider()`.

Note: even with this fix, `ValueSlider()` will report [ 1, 3, 5, 7, 9, *10* ] even though the `upperBound` value is not a multiple of `step`. That's easily worked around by client code if desired, so I'm not sure it should be fixed.